### PR TITLE
[Arc] remove padding attribute and use Bezier quadratic curve

### DIFF
--- a/arclayout/src/main/java/com/github/florent37/arclayout/ArcLayoutSettings.java
+++ b/arclayout/src/main/java/com/github/florent37/arclayout/ArcLayoutSettings.java
@@ -12,7 +12,6 @@ public class ArcLayoutSettings {
     private boolean cropInside = true;
     private float arcHeight;
     private float elevation;
-    private float arcPadding;
 
     private static float dpToPx(Context context, int dp) {
         Resources r = context.getResources();
@@ -22,7 +21,6 @@ public class ArcLayoutSettings {
     ArcLayoutSettings(Context context, AttributeSet attrs) {
         TypedArray styledAttributes = context.obtainStyledAttributes(attrs, R.styleable.ArcHeader, 0, 0);
         arcHeight = styledAttributes.getDimension(R.styleable.ArcHeader_arc_height, dpToPx(context, 10));
-        arcPadding = styledAttributes.getDimension(R.styleable.ArcHeader_arc_padding, dpToPx(context, 10));
 
         final int cropDirection = styledAttributes.getInt(R.styleable.ArcHeader_arc_cropDirection, CROP_INSIDE);
         cropInside = (cropDirection & CROP_INSIDE) == CROP_INSIDE;
@@ -44,9 +42,5 @@ public class ArcLayoutSettings {
 
     public float getArcHeight() {
         return arcHeight;
-    }
-
-    public float getArcPadding() {
-        return arcPadding;
     }
 }

--- a/arclayout/src/main/res/values/attrs.xml
+++ b/arclayout/src/main/res/values/attrs.xml
@@ -2,7 +2,6 @@
 <resources>
     <declare-styleable name="ArcHeader">
         <attr name="arc_height" format="dimension" />
-        <attr name="arc_padding" format="dimension" />
         <attr name="arc_cropDirection" format="enum">
             <enum name="cropInside" value="0" />
             <enum name="cropOutside" value="1"/>


### PR DESCRIPTION
Hello Florent,

I just discover an issue on this library, you can see a light horizontal line at the bottom of curved layout.

![device-2016-11-22-183309](https://cloud.githubusercontent.com/assets/7370259/20534656/45a8b1a8-b0e2-11e6-83d7-49baa555a2b4.png)

Tested device : nexus 5x, Android 6.0.1

* I think this issue can be due to the Path setup in your custom View.

* I also discover that we can use only the attribute "height" to define the arc, that will be more meaningful than using "height" and "padding" (quite confused for developers).

* Ken burns can repeatedly invalidate on the whole layout so use it carefully.

So i end up using quadratic Bezier curve instead of arcTo() and i can get the same result without weird horizontal line.

What do you think?

Thanks. 
